### PR TITLE
fix: publish event with the post full id

### DIFF
--- a/api.go
+++ b/api.go
@@ -10,6 +10,7 @@ var apiUrl = getEnv("API_URL", "http://localhost:4000")
 var hystrixApi = "API"
 
 type Post struct {
+	Id  string
 	Url string
 }
 

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func Redirect(w http.ResponseWriter, r *http.Request, postId string) {
 
 	ua := user_agent.New(r.UserAgent())
 	if ua != nil && !ua.Bot() {
-		RedirectBrowser(w, r, postId, post.Url)
+		RedirectBrowser(w, r, post.Id, post.Url)
 	} else {
 		http.Redirect(w, r, post.Url, http.StatusMovedPermanently)
 	}

--- a/redirect_test.go
+++ b/redirect_test.go
@@ -14,6 +14,7 @@ var getPostSuccess = func(t *testing.T, expId string) func(id string, r *http.Re
 
 		return Post{
 			Url: "https://www.dailynow.co",
+			Id: id,
 		}, nil
 	}
 }


### PR DESCRIPTION
With the migration to URL friendly post ids, the view mechanism broke.
This fix makes sure the redirector publishes events with the full id.

Closes dailydotdev/daily#170